### PR TITLE
Prevent future breaking change of `ics`

### DIFF
--- a/swc.py
+++ b/swc.py
@@ -144,7 +144,7 @@ with open(_OUTPUT_FOLDER + _SUCCESS_FILE, 'w', encoding='utf-8') as f:
 with open(_OUTPUT_FOLDER + _FAILURE_FILE, 'w', encoding='utf-8') as f:
     f.write('\n'.join(failed_deductions))
 with open(_OUTPUT_FOLDER + _ICS_FILE, 'w', encoding='utf-8') as f:
-    f.write(str(cal))
+    f.write(cal.serialize())
 
 # Overwrites history.
 history_file_path = _OUTPUT_FOLDER + _HISTORY_FILE


### PR DESCRIPTION
Fix the FutureWarning.

`/lib/python3.10/site-packages/ics/component.py:85: FutureWarning: Behaviour of str(Component) will change in version 0.9 to only return a short description, NOT the ics representation. Use the explicit Component.serialize() to get the ics representation.
  warnings.warn(`