### PR TITLE
Bump action & regex version

### DIFF
--- a/.github/workflows/analyze-wishlist.yml
+++ b/.github/workflows/analyze-wishlist.yml
@@ -8,16 +8,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
     steps:
 
-      - name: checkout repo content
-        uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - name: setup python
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.11.0'
-          
+          python-version: ${{ matrix.python-version }}
+
       - name: install python packages
         run: |
           python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dateparser>=1.1.2
 ics>=0.7.2
 matplotlib>=3.5.0
 requests>=2.26.0
-regex==2022.1.18
+regex==2023.8.8


### PR DESCRIPTION
- Bump several action versions to latest
- RegEx 2023.8.8 seems to work fine
- You can also add [PR test action](https://github.com/Vinfall/SteamWishlistCalendar/blob/main/.github/workflows/test.yml)  if you want that, don't forget change `${{ secrets.STEAMUID }}` to your Steam UID (or use GitHub repo secret)