### PR TITLE
Make ics pass validator

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+# Force CRLF in ICS as per RFC 5545 3.1. Content Lines
+*.ics text eol=crlf

--- a/.github/workflows/analyze-wishlist.yml
+++ b/.github/workflows/analyze-wishlist.yml
@@ -33,10 +33,10 @@ jobs:
 
       - name: check changes
         id: check_changes
-        run: if [[ $(git diff --name-only HEAD^ HEAD) == *"output/successful.txt"* ]]; then echo "::set-output name=changes::true"; else echo "::set-output name=changes::false"; fi
+        run: if [[ $(git diff --name-only HEAD) == *"output/successful.txt"* ]]; then echo "changes=true" > "$GITHUB_OUTPUT"; else echo "changes=false" > "$GITHUB_OUTPUT"; fi
 
       - name: commit files
-        if: steps.check_changes.outputs.changes == 'true'
+        if: ${{ steps.check_changes.outputs.changes == 'true' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -44,7 +44,7 @@ jobs:
           git commit -m "Update wishlist data." -a
 
       - name: push changes
-        if: steps.check_changes.outputs.changes == 'true'
+        if: ${{ steps.check_changes.outputs.changes == 'true' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/analyze-wishlist.yml
+++ b/.github/workflows/analyze-wishlist.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     steps:
 
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -27,9 +27,16 @@ jobs:
           pip install -r requirements.txt
 
       - name: execute py script
-        run: python swc.py -i=${{ secrets.STEAM_ID }} -d=True
-          
+        run: |
+          python swc.py -i=${{ secrets.STEAM_ID }} -d=True
+          sed -i 's/LAST-MODIFIED/DTSTAMP/g' output/wishlist.ics
+
+      - name: check changes
+        id: check_changes
+        run: if [[ $(git diff --name-only HEAD^ HEAD) == *"output/successful.txt"* ]]; then echo "::set-output name=changes::true"; else echo "::set-output name=changes::false"; fi
+
       - name: commit files
+        if: steps.check_changes.outputs.changes == 'true'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -37,6 +44,7 @@ jobs:
           git commit -m "Update wishlist data." -a
 
       - name: push changes
+        if: steps.check_changes.outputs.changes == 'true'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Make the ics output pass [iCalendar Validator](https://icalendar.org/validator.html) i.e. comply with RFC 5545, changes:
1. [RFC 5545 3.1. Content Lines](http://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html) requires CRLF for ics format
2. Change `LAST-MODIFIED` field to `DTSTAMP`. It's an upstream issue from `ics` package for not respecting RFC fields. `DTSTAMP` is used exactly for things like `LAST-MODIFIED`.
3. Action would now only push commits when `output/successful.txt` is changed, which can be seen as wishlist change. You can simply schedule it daily without commit flooding after merged.
4. Bump action version, I should have done it in #6...