### PR TITLE
Security & Format update

### DIFF
--- a/.github/workflows/analyze-wishlist.yml
+++ b/.github/workflows/analyze-wishlist.yml
@@ -27,9 +27,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: execute py script
-        run: |
-          python swc.py -i=${{ secrets.STEAM_ID }} -d=True
-          sed -i 's/LAST-MODIFIED/DTSTAMP/g' output/wishlist.ics
+        run: python swc.py -i=${{ secrets.STEAM_ID }} -d=True
 
       - name: check changes
         id: check_changes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dateparser>=1.2.0
 ics>=0.7.2
-matplotlib>=3.8.2
-requests>=2.31.0
-regex==2023.12.25
+matplotlib>=3.9.0
+requests>=2.32.0
+regex==2024.5.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dateparser>=1.2.0
-ics>=0.7.2
+ics==0.8.0.dev0
 matplotlib>=3.9.0
 requests>=2.32.0
 regex==2024.5.15

--- a/swc.py
+++ b/swc.py
@@ -133,12 +133,12 @@ for index in range(0, args.max_page):
         if value['type'] == 'DLC' and not args.include_dlc:
             continue
 
-        event = Event(uid=key, name=game_name,
+        event = Event(uid=key, summary=game_name,
                       description='https://store.steampowered.com/app/' + key + description_suffix,
-                      begin=release_date, last_modified=now,
+                      begin=release_date, last_modified=now, dtstamp=now,
                       categories=['game_release'])
         event.make_all_day()
-        cal.events.add(event)
+        cal.events.append(event)
 
     time.sleep(3)
 


### PR DESCRIPTION
- Bump dependencies, most importantly `request` to address a security issue, see https://github.com/Vinfall/SteamWishlistCalendar/security/dependabot/1 and https://github.com/psf/requests/pull/6655
- Update ics package to comply with the new RFC 5545 which obsoletes RFC 2445 (which ics 0.7.2 used), see https://github.com/Vinfall/VNDB-Calendar/commit/d9e36db40d53b4361105b4d567e497a892eb8a68. The generated iCalendar is a bit different but still backward-compatible. With this, SteamWishlistCalendar should now work in more clients.