### PR TITLE
Update

### DIFF
--- a/.github/workflows/analyze-wishlist.yml
+++ b/.github/workflows/analyze-wishlist.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.13"]
     steps:
 
       - name: Checkout repo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dateparser>=1.2.0
 ics==0.8.0.dev0
-matplotlib>=3.9.2
+matplotlib>=3.9.3
 requests>=2.32.3
-regex==2024.9.11
+regex==2024.11.6

--- a/swc.py
+++ b/swc.py
@@ -78,7 +78,13 @@ failed_deductions = []
 for index in range(0, args.max_page):
     params['p'] = index
     response = requests.get(url, params=params, timeout=10)
-    response_data = response.json()
+
+    # Steam API broken
+    try:
+        response_data = response.json()
+    except requests.exceptions.JSONDecodeError:
+        exit()
+
     if not response_data:
         # No more remaining items.
         break


### PR DESCRIPTION
Besides dependency & workflow update, this PR makes the script simply exits if the response is empty due to broken API (so wishlist would not be overwritten and become empty). Useless unless #13 is resolved but anyway...